### PR TITLE
Refactor networking and database into modules

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import threading
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional
+
+
+@dataclass
+class Item:
+    key: str
+    source: str
+    title: str
+    link: str
+    price_eur: Optional[float]
+    ship_eur: Optional[float]
+    total_eur: Optional[float]
+    type: str  # "🛒 Buy Now" | "🧷 Auction" | ""
+    thumb_url: Optional[str] = None
+    thumb_bytes: Optional[bytes] = None
+    trend: str = ""
+
+
+class Store:
+    """Thread-safe SQLite wrapper used for storing ad and price data."""
+
+    def __init__(self, db_path: str):
+        """Open a SQLite connection and ensure the schema exists."""
+        self.lock = threading.Lock()
+        self.conn = sqlite3.connect(db_path, check_same_thread=False, isolation_level=None)
+        self.conn.execute("PRAGMA journal_mode=WAL;")
+        self.conn.execute("PRAGMA synchronous=NORMAL;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        """Create tables if they are missing."""
+        with self.lock, self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ads(
+                    key TEXT PRIMARY KEY,
+                    source TEXT,
+                    title TEXT,
+                    link TEXT,
+                    last_price REAL,
+                    last_ship REAL,
+                    last_total REAL,
+                    type TEXT,
+                    first_seen TEXT,
+                    last_seen TEXT
+                )
+                """
+            )
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS price_history(
+                    key TEXT,
+                    seen_at TEXT,
+                    price REAL
+                )
+                """
+            )
+
+    def upsert_item(self, it: Item) -> None:
+        """Insert or update an Item and record its price history."""
+        now = datetime.now(timezone.utc).isoformat()
+        with self.lock, self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO ads(key, source, title, link, last_price, last_ship, last_total, type, first_seen, last_seen)
+                VALUES(?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(key) DO UPDATE SET
+                    source=excluded.source,
+                    title=excluded.title,
+                    link=excluded.link,
+                    last_price=excluded.last_price,
+                    last_ship=excluded.last_ship,
+                    last_total=excluded.last_total,
+                    type=excluded.type,
+                    last_seen=excluded.last_seen
+                """,
+                (
+                    it.key,
+                    it.source,
+                    it.title,
+                    it.link,
+                    it.price_eur,
+                    it.ship_eur,
+                    it.total_eur,
+                    it.type,
+                    now,
+                    now,
+                ),
+            )
+            price_for_hist = it.total_eur if (it.total_eur is not None) else it.price_eur
+            if price_for_hist is not None:
+                self.conn.execute(
+                    "INSERT INTO price_history(key, seen_at, price) VALUES(?,?,?)",
+                    (it.key, now, price_for_hist),
+                )
+
+    def get_price_history(self, key: str, limit: int = 32) -> List[float]:
+        """Return a list of past prices for the given ad key."""
+        with self.lock, self.conn:
+            rows = [
+                r[0]
+                for r in self.conn.execute(
+                    "SELECT price FROM price_history WHERE key=? ORDER BY seen_at ASC",
+                    (key,),
+                )
+            ]
+        if len(rows) > limit:
+            idxs = [int(i * (len(rows) - 1) / (limit - 1)) for i in range(limit)]
+            rows = [rows[i] for i in idxs]
+        return rows
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        with self.lock:
+            self.conn.close()
+

--- a/net.py
+++ b/net.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import time
+import threading
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+DESKTOP_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+ACCEPT_LANG = "nl-NL,nl;q=0.9,en;q=0.8"
+REQUEST_TIMEOUT = 20
+POLITE_DELAY_SEC = 1.2
+
+
+class DummyResponse:
+    """Fallback response object returned when HTTP requests fail."""
+
+    def __init__(self, url: str, status_code: int = 0, text: str = "", content: bytes = b""):
+        self.url = url
+        self.status_code = status_code
+        self.text = text
+        self.content = content
+
+
+def make_session() -> requests.Session:
+    """Create a requests session with retry and desktop browser headers."""
+    s = requests.Session()
+    retries = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
+    s.headers.update(
+        {
+            "User-Agent": DESKTOP_UA,
+            "Accept-Language": ACCEPT_LANG,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Connection": "keep-alive",
+        }
+    )
+    return s
+
+
+def polite_get(session: requests.Session, url: str, stop_event: threading.Event) -> requests.Response | DummyResponse:
+    """GET a URL respecting stop signals."""
+    if stop_event.is_set():
+        return DummyResponse(url=url)
+    try:
+        resp = session.get(url, timeout=REQUEST_TIMEOUT)
+        time.sleep(POLITE_DELAY_SEC)
+        return resp
+    except Exception:
+        return DummyResponse(url=url)
+
+
+def fetch_bytes(session: requests.Session, url: str, stop_event: threading.Event) -> bytes | None:
+    """Fetch raw bytes from a URL, respecting stop signals."""
+    if not url or stop_event.is_set():
+        return None
+    try:
+        r = session.get(url, timeout=REQUEST_TIMEOUT)
+        if r.status_code == 200:
+            time.sleep(POLITE_DELAY_SEC / 2)
+            return r.content
+    except Exception:
+        pass
+    return None
+


### PR DESCRIPTION
## Summary
- factor out SQLite store and item dataclass into dedicated `db` module with `ON CONFLICT` upsert
- create `net` module using requests' retry-enabled session and simpler helpers
- update main script to consume the new modules

## Testing
- `python -m py_compile Untitled-1.py db.py net.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a799f938fc832b8123a4630eecd648